### PR TITLE
refactor(manifest): Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 structopt = "0.3.23"
 thiserror = "1.0"
-regex = "1.x"
+regex = "1.5"
 log = "0.4"
 log4rs = {version = "1.0", features = ["json_encoder", "file_appender", "console_appender"]}
 openssl = "0.10.36"
@@ -29,3 +29,7 @@ hex = "0.4.3"
 url = "2.2.2"
 urlencoding = "2.1"
 unm_macro = { path = "./unm_macro" }
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Standardize the version number of a dependency (regex). "1.x" is not the form of the specified version number recommended in the [Cargo Book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
Add release profile: enabling LTO can reduce the binary size and setting codegen-units to 1 may optimize performance.

BTW, I do not recommend reducing the binary size by setting `opt-level` to "s" or "z", because that may cause performance loss.