### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -84,7 +84,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
@@ -230,9 +230,9 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "cfg-if"
@@ -250,7 +250,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -365,15 +365,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -646,15 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -792,15 +783,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -819,9 +810,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
@@ -845,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
@@ -906,9 +897,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
@@ -922,7 +913,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1034,11 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1130,15 +1121,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1196,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1296,17 +1287,18 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
- "windows-sys",
+ "lazy_static",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1317,15 +1309,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "security-framework"
-version = "2.8.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1336,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1424,7 +1416,7 @@ dependencies = [
  "colored",
  "log",
  "time 0.3.17",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1491,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1529,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1599,14 +1591,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1767,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typed-builder"
@@ -1784,15 +1776,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -1817,7 +1809,7 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unm_api_utils"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "concat-idents",
  "log",
@@ -1852,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1864,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_bilibili"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1894,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_joox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1915,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_kugou"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1936,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_kuwo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1957,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_migu"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_pyncm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1994,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_qq"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2021,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "unm_engine_ytdl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2052,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "unm_request"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "cached",
@@ -2067,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "unm_rest_api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2095,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "unm_selector"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "once_cell",
  "serde",
@@ -2116,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "unm_types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "derive_builder",
  "reqwest",
@@ -2292,60 +2284,103 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/api-utils/Cargo.toml
+++ b/api-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_api_utils"
 description = "The utilities for developing UnblockNeteaseMusic API."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "./README.md"
@@ -11,11 +11,11 @@ readme = "./README.md"
 [dependencies]
 concat-idents = "1.1.4"
 log = "0.4.17"
-unm_engine = { version = "0.3.0", path = "../engine-base" }
-unm_engine_bilibili = { version = "0.3.0", path = "../engines/bilibili" }
-unm_engine_joox = { version = "0.3.0", path = "../engines/joox" }
-unm_engine_kugou = { version = "0.3.0", path = "../engines/kugou" }
-unm_engine_kuwo = { version = "0.3.0", path = "../engines/kuwo" }
-unm_engine_pyncm = { version = "0.3.0", path = "../engines/pyncm" }
-unm_engine_qq = { version = "0.3.0", path = "../engines/qq" }
-unm_engine_ytdl = { version = "0.3.0", path = "../engines/ytdl" }
+unm_engine = { version = "0.4.0", path = "../engine-base" }
+unm_engine_bilibili = { version = "0.4.0", path = "../engines/bilibili" }
+unm_engine_joox = { version = "0.4.0", path = "../engines/joox" }
+unm_engine_kugou = { version = "0.4.0", path = "../engines/kugou" }
+unm_engine_kuwo = { version = "0.4.0", path = "../engines/kuwo" }
+unm_engine_pyncm = { version = "0.4.0", path = "../engines/pyncm" }
+unm_engine_qq = { version = "0.4.0", path = "../engines/qq" }
+unm_engine_ytdl = { version = "0.4.0", path = "../engines/ytdl" }

--- a/engine-base/Cargo.toml
+++ b/engine-base/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine"
 description = "The engine base for UnblockNeteaseMusic, including the executor and the Engine trait."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../README.md"
@@ -14,4 +14,4 @@ async-trait = "0.1.61"
 futures = "0.3.25"
 log = "0.4.17"
 thiserror = "1.0.38"
-unm_types = { version = "0.3.0", path = "../types" }
+unm_types = { version = "0.4.0", path = "../types" }

--- a/engine-demo/Cargo.toml
+++ b/engine-demo/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 futures = "0.3.25"
 mimalloc = "0.1.34"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-unm_api_utils = { version = "0.3.0", path = "../api-utils" }
+unm_api_utils = { version = "0.4.0", path = "../api-utils" }
 unm_test_utils = { version = "0.1.0", path = "../test-utils" }
-unm_types = { version = "0.3.0", path = "../types" }
+unm_types = { version = "0.4.0", path = "../types" }

--- a/engines/bilibili/Cargo.toml
+++ b/engines/bilibili/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_bilibili"
 description = "The Bilibili engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -14,10 +14,10 @@ async-trait = "0.1.61"
 http = "0.2.8"
 log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 url = "2.3.1"
 
 [dev-dependencies]

--- a/engines/joox/Cargo.toml
+++ b/engines/joox/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_joox"
 description = "The Joox engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -18,10 +18,10 @@ once_cell = "1.17.0"
 regex = "1.7.1"
 reqwest = { version = "0.11.14", features = ["native-tls-vendored"] }
 serde_json = "1.0.91"
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/engines/kugou/Cargo.toml
+++ b/engines/kugou/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_kugou"
 description = "The Kugou engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -18,10 +18,10 @@ log = "0.4.17"
 reqwest = { version = "0.11.14", features = ["native-tls-vendored"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/engines/kuwo/Cargo.toml
+++ b/engines/kuwo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_kuwo"
 description = "The Kuwo engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -18,10 +18,10 @@ log = "0.4.17"
 random-string = "1.0.0"
 reqwest = { version = "0.11.14", features = ["native-tls-vendored"] }
 serde = { version = "1.0.152", features = ["derive"] }
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/engines/migu/Cargo.toml
+++ b/engines/migu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_migu"
 description = "The Migu engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -15,10 +15,10 @@ http = "0.2.8"
 log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 url = "2.3.1"
 
 [dev-dependencies]

--- a/engines/pyncm/Cargo.toml
+++ b/engines/pyncm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_pyncm"
 description = "The PyNCM engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -14,9 +14,9 @@ async-trait = "0.1.61"
 http = "0.2.8"
 log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_types = { version = "0.4.0", path = "../../types" }
 url = "2.3.1"
 
 [dev-dependencies]

--- a/engines/qq/Cargo.toml
+++ b/engines/qq/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_qq"
 description = "The QQ engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
@@ -23,10 +23,10 @@ reqwest = "0.11.14"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 thiserror = "1.0.38"
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_request = { version = "0.3.0", path = "../../request" }
-unm_selector = { version = "0.3.0", path = "../../selector" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_request = { version = "0.4.0", path = "../../request" }
+unm_selector = { version = "0.4.0", path = "../../selector" }
+unm_types = { version = "0.4.0", path = "../../types" }
 url = "2.3.1"
 
 [dev-dependencies]

--- a/engines/ytdl/Cargo.toml
+++ b/engines/ytdl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_engine_ytdl"
 description = "The YtDl (youtube-dl, yt-dlp, …) engine for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../../README.md"
 edition = "2021"
@@ -16,8 +16,8 @@ log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tokio = { version = "1.24.2", features = ["process"] }
-unm_engine = { version = "0.3.0", path = "../../engine-base" }
-unm_types = { version = "0.3.0", path = "../../types" }
+unm_engine = { version = "0.4.0", path = "../../engine-base" }
+unm_types = { version = "0.4.0", path = "../../types" }
 winapi = "0.3.9"
 
 [dev-dependencies]

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -16,9 +16,9 @@ mimalloc = "0.1.34"
 napi = { version = "2.10.9", features = ["full"] }
 napi-derive = "2.9.5"
 simple_logger = "4.0.0"
-unm_api_utils = { version = "0.3.0", path = "../api-utils" }
-unm_engine = { version = "0.3.0", path = "../engine-base" }
-unm_types = { version = "0.3.0", path = "../types" }
+unm_api_utils = { version = "0.4.0", path = "../api-utils" }
+unm_engine = { version = "0.4.0", path = "../engine-base" }
+unm_types = { version = "0.4.0", path = "../types" }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unblockneteasemusic/rust-napi",
   "description": "Node.js binding for UNM Rust",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "keywords": [
     "unm",
     "unblockneteasemusic",

--- a/request/Cargo.toml
+++ b/request/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_request"
 description = "The request-related methods for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../README.md"
 edition = "2021"

--- a/rest-api/Cargo.toml
+++ b/rest-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unm_rest_api"
 description = "The RESTful API that can deal with UnblockNeteaseMusic API."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
@@ -26,8 +26,8 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-unm_api_utils = { version = "0.3.0", path = "../api-utils" }
-unm_engine = { version = "0.3.0", path = "../engine-base" }
-unm_engine_bilibili = { version = "0.3.0", path = "../engines/bilibili" }
-unm_types = { version = "0.3.0", path = "../types" }
+unm_api_utils = { version = "0.4.0", path = "../api-utils" }
+unm_engine = { version = "0.4.0", path = "../engine-base" }
+unm_engine_bilibili = { version = "0.4.0", path = "../engines/bilibili" }
+unm_types = { version = "0.4.0", path = "../types" }
 url = "2.3.1"

--- a/selector/Cargo.toml
+++ b/selector/Cargo.toml
@@ -2,14 +2,14 @@
 name = "unm_selector"
 description = "The algorithm for UnblockNeteaseMusic, determining what Song to return."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../README.md"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-unm_types = { version = "0.3.0", path = "../types" }
+unm_types = { version = "0.4.0", path = "../types" }
 
 [dev-dependencies]
 once_cell = "1.17.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 futures = "0.3.25"
 log = "0.4.17"
 simple_logger = "4.0.0"
-unm_engine = { version = "0.3.0", path = "../engine-base" }
-unm_types = { version = "0.3.0", path = "../types" }
+unm_engine = { version = "0.4.0", path = "../engine-base" }
+unm_types = { version = "0.4.0", path = "../types" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unm_types"
 description = "The type definitions for UnblockNeteaseMusic."
 license = "LGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/UnblockNeteaseMusic/server-rust"
 readme = "../README.md"
 edition = "2021"


### PR DESCRIPTION
unm_api_utils@0.4.0
unm_engine@0.4.0
unm_engine_bilibili@0.4.0
unm_engine_joox@0.4.0
unm_engine_kugou@0.4.0
unm_engine_kuwo@0.4.0
unm_engine_migu@0.4.0
unm_engine_pyncm@0.4.0
unm_engine_qq@0.4.0
unm_engine_ytdl@0.4.0
unm_request@0.4.0
unm_rest_api@0.4.0
unm_selector@0.4.0
unm_types@0.4.0

Generated by cargo-workspaces
